### PR TITLE
Use os-appropriate open command to get api key

### DIFF
--- a/bm.js
+++ b/bm.js
@@ -177,7 +177,14 @@ if (argv.help) {
   }
 } else {
   console.log("No ~/.bmndrrc detected... starting authentication process...");
-  exec('xdg-open https://www.beeminder.com/api/v1/auth_token.json', function () {
+  var open
+  if (process.platform === 'linux') {
+    open = 'xdg-open'
+  } else if (process.platform === 'darwin') {
+    open = 'open'
+  }
+
+  exec(open + ' https://www.beeminder.com/api/v1/auth_token.json', function () {
     console.log("A browser window has opened that will show you your auth_token.\nCopy that and paste it here.");
 
     prompt.start();


### PR DESCRIPTION
Adds OS X specific `open` command to get API key for `~/.bmndrrc`.

Closes #1.
